### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/copy-issue-labels.yml
+++ b/.github/workflows/copy-issue-labels.yml
@@ -2,6 +2,9 @@
 # Reference: https://github.com/marketplace/actions/copy-issue-labels
 
 name: Copy Issue Labels to PR
+permissions:
+  issues: write
+  pull-requests: write
 
 on: 
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/AkshitTiwarii/carbonx/security/code-scanning/1](https://github.com/AkshitTiwarii/carbonx/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to limit the permissions of the GITHUB_TOKEN, following the principle of least privilege. This block should be set either at the workflow (top-level, directly under the `name:` or `on:` block) or at the job level (inside the `copy-labels:` job). Since there is only one job, setting it at the workflow level is sufficient and most straightforward.

Since the workflow uses an action to copy issue labels from linked issues to pull requests, it likely needs write access to `issues` and maybe `pull-requests`. To be safest, set `issues: write` and `pull-requests: write`, and everything else to either `read` or omit (which defaults to none). Add the following block directly under the `name:` in `.github/workflows/copy-issue-labels.yml`:

```yaml
permissions:
  issues: write
  pull-requests: write
```

No imports, methods, or further definitions are needed beyond this block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
