### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/close-stale-issues-prs.yml
+++ b/.github/workflows/close-stale-issues-prs.yml
@@ -10,6 +10,10 @@ on:
 
 jobs:
   stale:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10


### PR DESCRIPTION
Potential fix for [https://github.com/AkshitTiwarii/carbonx/security/code-scanning/2](https://github.com/AkshitTiwarii/carbonx/security/code-scanning/2)

The recommended approach is to explicitly set the minimal necessary permissions for the job in the workflow YAML. For the `actions/stale` action, this generally means providing `issues: write` and `pull-requests: write` permissions, and in some cases `contents: write` if the action needs to make changes to files or comments associated with contents. Put the `permissions` block either at the root of the YAML (to apply to all jobs), or inside the `stale` job (to restrict it to that job). In this workflow, it's appropriate to add it at the job level for clarity and the lowest risk.

Specifically, add the following under `jobs.stale` (i.e., under line 12 in your workflow):

```yaml
    permissions:
      contents: write
      issues: write
      pull-requests: write
```

Adjust indentation to align with the rest of the job-level keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
