### PR TITLE
feat(backend): add /health and /ready endpoints + tests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,14 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, status
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from routers import auth, credits, rewards
 import os
 import json
+from datetime import datetime
+import logging
+
+# Basic logger
+logger = logging.getLogger("uvicorn.error")
 
 app = FastAPI(title="CarbonX Backend", version="0.1.0")
 
@@ -24,42 +30,95 @@ app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
 app.include_router(credits.router, prefix="/api/credits", tags=["credits"])
 app.include_router(rewards.router, prefix="/api/rewards", tags=["rewards"])
 
+
 @app.get("/")
 def root():
     return {"status": "ok", "service": "carbonx-backend"}
+
 
 @app.get("/api/debug/db")
 def debug_database():
     """Debug endpoint to check rewards database state"""
     try:
         db_file = "rewards_db.json"
-        
+
         # Check if file exists
         file_exists = os.path.exists(db_file)
-        
+
         # Try to read the file
         db_content = None
         file_size = 0
         user_count = 0
-        
+
         if file_exists:
             file_size = os.path.getsize(db_file)
             try:
-                with open(db_file, 'r') as f:
+                with open(db_file, "r", encoding="utf-8") as f:
                     db_content = json.load(f)
                     user_count = len(db_content) if isinstance(db_content, dict) else 0
             except Exception as e:
                 db_content = f"Error reading: {str(e)}"
-        
+
         return {
             "file_exists": file_exists,
             "file_size_bytes": file_size,
             "user_count": user_count,
             "working_directory": os.getcwd(),
-            "db_sample": db_content if isinstance(db_content, dict) else str(db_content)[:500]
+            "db_sample": db_content if isinstance(db_content, dict) else str(db_content)[:500],
         }
     except Exception as e:
-        return {
-            "error": str(e),
-            "working_directory": os.getcwd()
-        }
+        logger.exception("Error in debug_database")
+        return {"error": str(e), "working_directory": os.getcwd()}
+
+
+# -------------------------
+# Health & Readiness probes
+# -------------------------
+@app.get("/health", summary="Liveness probe")
+def health():
+    """
+    Liveness probe. Return 200 when the process is alive.
+    """
+    return {"status": "ok", "timestamp": datetime.utcnow().isoformat() + "Z"}
+
+
+@app.get("/ready", summary="Readiness probe")
+def ready():
+    """
+    Readiness probe. Attempts quick checks of critical dependencies.
+    Current implementation checks the presence/readability of `rewards_db.json`.
+    Replace or extend these checks as needed (DB, cache, external services).
+    """
+    checks = {"rewards_db": {"ok": False, "reason": None}}
+
+    # Check rewards_db.json
+    db_file = "rewards_db.json"
+    try:
+        if not os.path.exists(db_file):
+            checks["rewards_db"]["ok"] = False
+            checks["rewards_db"]["reason"] = "file_not_found"
+        else:
+            # try reading and parsing
+            try:
+                with open(db_file, "r", encoding="utf-8") as f:
+                    _ = json.load(f)
+                checks["rewards_db"]["ok"] = True
+                checks["rewards_db"]["reason"] = None
+            except Exception as e:
+                checks["rewards_db"]["ok"] = False
+                checks["rewards_db"]["reason"] = f"read_error: {str(e)[:200]}"
+    except Exception as e:
+        # Any unexpected error
+        logger.exception("Error while running readiness check")
+        checks["rewards_db"]["ok"] = False
+        checks["rewards_db"]["reason"] = f"unexpected_error: {str(e)[:200]}"
+
+    # decide overall readiness
+    all_ok = all(item["ok"] for item in checks.values())
+
+    body = {"status": "ready" if all_ok else "not_ready", "checks": checks, "timestamp": datetime.utcnow().isoformat() + "Z"}
+
+    if all_ok:
+        return body
+    else:
+        return JSONResponse(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, content=body)

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -1,0 +1,30 @@
+# backend/routes/health.py
+from datetime import datetime
+from fastapi import APIRouter, status
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+@router.get("/health", summary="Liveness probe")
+def health():
+    """
+    Simple liveness probe. Returns 200 if process is up.
+    """
+    return {
+        "status": "ok",
+        "timestamp": datetime.utcnow().isoformat() + "Z"
+    }
+
+@router.get("/ready", summary="Readiness probe")
+async def ready():
+    """
+    Readiness probe. Replace the stub with real checks like DB ping.
+    Returns 200 when dependencies look OK, otherwise 503.
+    """
+    # TODO: Replace this stub with real checks (DB, cache, other services)
+    dependencies_ok = True
+
+    if dependencies_ok:
+        return {"status": "ready"}
+    return JSONResponse(status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                        content={"status": "not_ready"})

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,33 @@
+# backend/tests/test_health.py
+import os
+import sys
+from fastapi.testclient import TestClient
+
+# Ensure backend folder (the parent of this tests folder) is on sys.path
+HERE = os.path.dirname(__file__)             # backend/tests
+ROOT = os.path.abspath(os.path.join(HERE, ".."))  # backend
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+# Now import the FastAPI app from backend/main.py
+try:
+    from main import app
+except Exception as e:
+    # helpful error if import fails
+    raise RuntimeError(f"Failed to import 'main.app' — check path. Details: {e}")
+
+client = TestClient(app)
+
+
+def test_health():
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json().get("status") == "ok"
+
+
+def test_ready_returns_200_or_503():
+    r = client.get("/ready")
+    assert r.status_code in (200, 503)
+    data = r.json()
+    assert "status" in data
+    assert "checks" in data


### PR DESCRIPTION
# 📝 Pull Request: Add health & readiness probes

## 📄 Description
This PR adds two important backend endpoints used for liveness and readiness checks.

### Added:
- `GET /health` → liveness probe (always returns 200 with timestamp)
- `GET /ready` → readiness probe (checks if `rewards_db.json` exists & is readable)

These endpoints help with local development, Docker `HEALTHCHECK`, CI smoke tests, and readiness/liveness probes for deployments (Kubernetes, etc).

---

## 🔗 Related Issues
Fixes: https://github.com/AkshitTiwarii/carbonx/issues/88

---

## 🧩 Type of Change
- [x] ✨ New Feature  
- [x] 🧾 Documentation Update (added test + README note suggested)  

---

## ✅ Checklist
- [x] I have performed a self-review of my code.  
- [x] I have added tests for the new endpoints.  
- [x] I have tested the changes locally and they work as expected.  
- [x] I linked the related issue above.

---

## ✅ What was changed
- `backend/main.py` — added `/health` and `/ready` endpoints and lightweight readiness checks using `rewards_db.json`.
- `backend/routers/health.py` — (if present) health router implemented.
- `backend/tests/test_health.py` — tests for `/health` and `/ready`.

---

## 🧪 How to test locally
1. cd into backend:
   ```bash
   cd backend
   uvicorn main:app --reload --port 8000
   pytest -q

